### PR TITLE
Docker: change path to docker-entrypoint for mariadb 10.5 image

### DIFF
--- a/mariadb-10-5/entrypoint.sh
+++ b/mariadb-10-5/entrypoint.sh
@@ -2,7 +2,7 @@
 set -eo pipefail
 set -x
 
-/docker-entrypoint.sh mysqld 1>/srv/output.log 2>&1 &
+/usr/local/bin/docker-entrypoint.sh mysqld 1>/srv/output.log 2>&1 &
 
 wait-for-it localhost:3306 --timeout=30 --strict 1>/srv/output.log 2>&1
 


### PR DESCRIPTION
- mariadb docker image 10.4 has symlinks to docker-entrypoint.sh
+ call docker-entrypoint.sh directly from its location