### PR TITLE
Add CI rollout baseline

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -13,14 +13,10 @@ permissions:
   contents: read
 
 jobs:
-  build:
-    name: "Build"
-    uses: dockette/.github/.github/workflows/docker.yml@master
-    secrets: inherit
-    with:
-        image: "dockette/dbdump"
-        tag: "${{ matrix.item }}"
-        context: "${{ matrix.item }}"
+  test:
+    name: "Test"
+    runs-on: "ubuntu-latest"
+
     strategy:
       matrix:
         include:
@@ -36,3 +32,62 @@ jobs:
           - item: mariadb-11-8
 
       fail-fast: false
+
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v4
+
+      - name: "Set up Docker Buildx"
+        uses: docker/setup-buildx-action@v3
+
+      - name: "Build image"
+        uses: docker/build-push-action@v6
+        with:
+          context: "${{ matrix.item }}"
+          load: true
+          tags: "dockette/dbdump:${{ matrix.item }}"
+
+      - name: "Test image"
+        run: "make test VERSION=${{ matrix.item }} DOCKER_TAG=${{ matrix.item }}"
+
+  build:
+    name: "Build"
+    needs: ["test"]
+    uses: dockette/.github/.github/workflows/docker.yml@master
+    secrets: inherit
+    with:
+      image: "dockette/dbdump"
+      tag: "${{ matrix.item }}"
+      context: "${{ matrix.item }}"
+    strategy:
+      matrix:
+        include:
+          - item: mariadb-10-2
+          - item: mariadb-10-4
+          - item: mariadb-10-6
+          - item: mariadb-10-11
+          - item: mariadb-11-1
+          - item: mariadb-11-2
+          - item: mariadb-11-4
+          - item: mariadb-11-5
+          - item: mariadb-11-7
+          - item: mariadb-11-8
+
+      fail-fast: false
+
+  docs:
+    name: "Docs"
+    runs-on: "ubuntu-latest"
+    needs: ["build"]
+    if: github.ref == 'refs/heads/master'
+
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v4
+
+      - name: "Update Docker Hub description"
+        uses: peter-evans/dockerhub-description@v5
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          repository: "dockette/dbdump"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -54,6 +54,7 @@ jobs:
   build:
     name: "Build"
     needs: ["test"]
+    if: github.ref == 'refs/heads/master'
     uses: dockette/.github/.github/workflows/docker.yml@master
     secrets: inherit
     with:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -22,6 +22,7 @@ jobs:
         include:
           - item: mariadb-10-2
           - item: mariadb-10-4
+          - item: mariadb-10-5
           - item: mariadb-10-6
           - item: mariadb-10-11
           - item: mariadb-11-1
@@ -48,7 +49,7 @@ jobs:
           tags: "dockette/dbdump:${{ matrix.item }}"
 
       - name: "Test image"
-        run: "make test VERSION=${{ matrix.item }} DOCKER_TAG=${{ matrix.item }}"
+        run: "make test DOCKER_VERSION=${{ matrix.item }} DOCKER_TAG=${{ matrix.item }}"
 
   build:
     name: "Build"
@@ -64,6 +65,7 @@ jobs:
         include:
           - item: mariadb-10-2
           - item: mariadb-10-4
+          - item: mariadb-10-5
           - item: mariadb-10-6
           - item: mariadb-10-11
           - item: mariadb-11-1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,19 @@
+# AGENTS.md
+
+## Project
+
+Docker image repository in the Dockette organization.
+
+## Commands
+
+- `make build` builds the default Docker image.
+- `make test` runs the repository smoke tests.
+- `make run` starts the image for local use.
+
+## Guidelines
+
+- Keep Dockerfiles, `Makefile`, README, and GitHub Actions workflow changes aligned.
+- Prefer `DOCKER_*` names for Docker-related Makefile variables.
+- Place `.PHONY: <target>` directly above each Makefile target.
+- Keep README badges and maintenance sections consistent with other Dockette image repos.
+- Do not introduce unrelated formatting or structural changes.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,18 +2,34 @@
 
 ## Project
 
-Docker image repository in the Dockette organization.
+Dockette DBDUMP builds `dockette/dbdump`, ready-to-use MariaDB/MySQL dump helper images. Each tag wraps an official `mariadb:<version>` image, installs `wait-for-it`, copies a version-local `entrypoint.sh`, and exposes dump/client binaries for backup workflows.
+
+## Images
+
+- Default image: `dockette/dbdump:mariadb-11-8` from build context `mariadb-11-8/`.
+- Supported tags in `Makefile` and README: `mariadb-10-2`, `mariadb-10-4`, `mariadb-10-6`, `mariadb-10-11`, `mariadb-11-1`, `mariadb-11-2`, `mariadb-11-4`, `mariadb-11-5`, `mariadb-11-7`, and `mariadb-11-8`.
+- Each `mariadb-*` directory is its own Docker build context and should contain both `Dockerfile` and `entrypoint.sh`.
+- GitHub Actions builds and tests every matrix item, then publishes each tag through the shared Dockette Docker workflow on `master` and the weekly schedule.
 
 ## Commands
 
-- `make build` builds the default Docker image.
-- `make test` runs the repository smoke tests.
-- `make run` starts the image for local use.
+- `make build` builds `${DOCKER_IMAGE}:${DOCKER_TAG}` from `${DOCKER_VERSION}/`.
+- `make test` verifies `mysqldump --version`, `mariadb-dump --version`, and `mariadb --version` in the current tag.
+- `make run` opens an interactive container for the current tag.
+- `make build-all` and `make test-all` iterate over every `DOCKER_VERSIONS` entry.
+- `make mariadb-11-8` builds and tests that specific version; equivalent version targets are generated for every listed tag.
+
+## Testing Notes
+
+- Run `make test DOCKER_VERSION=<tag> DOCKER_TAG=<tag>` after changing a version directory.
+- Use `make -n build test run` to dry-run command wiring without requiring Docker.
+- The workflow currently passes `VERSION=...` to `make test`; this Makefile uses `DOCKER_VERSION`, so keep any workflow edits aligned with Makefile variable names.
 
 ## Guidelines
 
-- Keep Dockerfiles, `Makefile`, README, and GitHub Actions workflow changes aligned.
+- Keep version directories, `DOCKER_VERSIONS`, README image list, and `.github/workflows/docker.yml` matrices aligned when adding or removing MariaDB versions.
 - Prefer `DOCKER_*` names for Docker-related Makefile variables.
 - Place `.PHONY: <target>` directly above each Makefile target.
 - Keep README badges and maintenance sections consistent with other Dockette image repos.
+- Keep changes duplicated across version directories only when the runtime behavior must stay identical.
 - Do not introduce unrelated formatting or structural changes.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ Dockette DBDUMP builds `dockette/dbdump`, ready-to-use MariaDB/MySQL dump helper
 ## Images
 
 - Default image: `dockette/dbdump:mariadb-11-8` from build context `mariadb-11-8/`.
-- Supported tags in `Makefile` and README: `mariadb-10-2`, `mariadb-10-4`, `mariadb-10-6`, `mariadb-10-11`, `mariadb-11-1`, `mariadb-11-2`, `mariadb-11-4`, `mariadb-11-5`, `mariadb-11-7`, and `mariadb-11-8`.
+- Supported tags in `Makefile` and README: `mariadb-10-2`, `mariadb-10-4`, `mariadb-10-5`, `mariadb-10-6`, `mariadb-10-11`, `mariadb-11-1`, `mariadb-11-2`, `mariadb-11-4`, `mariadb-11-5`, `mariadb-11-7`, and `mariadb-11-8`.
 - Each `mariadb-*` directory is its own Docker build context and should contain both `Dockerfile` and `entrypoint.sh`.
 - GitHub Actions builds and tests every matrix item, then publishes each tag through the shared Dockette Docker workflow on `master` and the weekly schedule.
 
@@ -23,7 +23,7 @@ Dockette DBDUMP builds `dockette/dbdump`, ready-to-use MariaDB/MySQL dump helper
 
 - Run `make test DOCKER_VERSION=<tag> DOCKER_TAG=<tag>` after changing a version directory.
 - Use `make -n build test run` to dry-run command wiring without requiring Docker.
-- The workflow currently passes `VERSION=...` to `make test`; this Makefile uses `DOCKER_VERSION`, so keep any workflow edits aligned with Makefile variable names.
+- The workflow passes `DOCKER_VERSION=...` to `make test`; keep workflow edits aligned with Makefile variable names.
 
 ## Guidelines
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,12 @@
 DOCKER_IMAGE=dockette/dbdump
-VERSION?=mariadb-11-8
-DOCKER_TAG?=${VERSION}
-VERSIONS=mariadb-10-2 mariadb-10-4 mariadb-10-6 mariadb-10-11 mariadb-11-1 mariadb-11-2 mariadb-11-4 mariadb-11-5 mariadb-11-7 mariadb-11-8
+DOCKER_VERSION?=mariadb-11-8
+DOCKER_TAG?=${DOCKER_VERSION}
+DOCKER_VERSIONS=mariadb-10-2 mariadb-10-4 mariadb-10-6 mariadb-10-11 mariadb-11-1 mariadb-11-2 mariadb-11-4 mariadb-11-5 mariadb-11-7 mariadb-11-8
 
-.PHONY: build test run build-all test-all ${VERSIONS}
+.PHONY: build test run build-all test-all ${DOCKER_VERSIONS}
 
 build:
-	docker build -t ${DOCKER_IMAGE}:${DOCKER_TAG} ${VERSION}/
+	docker build -t ${DOCKER_IMAGE}:${DOCKER_TAG} ${DOCKER_VERSION}/
 
 test:
 	docker run --rm ${DOCKER_IMAGE}:${DOCKER_TAG} mysqldump --version
@@ -17,10 +17,10 @@ run:
 	docker run --rm -it ${DOCKER_IMAGE}:${DOCKER_TAG}
 
 build-all:
-	for version in ${VERSIONS}; do ${MAKE} VERSION=$$version DOCKER_TAG=$$version build; done
+	for version in ${DOCKER_VERSIONS}; do ${MAKE} DOCKER_VERSION=$$version DOCKER_TAG=$$version build; done
 
 test-all:
-	for version in ${VERSIONS}; do ${MAKE} VERSION=$$version DOCKER_TAG=$$version test; done
+	for version in ${DOCKER_VERSIONS}; do ${MAKE} DOCKER_VERSION=$$version DOCKER_TAG=$$version test; done
 
-${VERSIONS}:
-	${MAKE} VERSION=$@ DOCKER_TAG=$@ build test
+${DOCKER_VERSIONS}:
+	${MAKE} DOCKER_VERSION=$@ DOCKER_TAG=$@ build test

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 DOCKER_IMAGE=dockette/dbdump
 DOCKER_VERSION?=mariadb-11-8
 DOCKER_TAG?=${DOCKER_VERSION}
-DOCKER_VERSIONS=mariadb-10-2 mariadb-10-4 mariadb-10-6 mariadb-10-11 mariadb-11-1 mariadb-11-2 mariadb-11-4 mariadb-11-5 mariadb-11-7 mariadb-11-8
+DOCKER_VERSIONS=mariadb-10-2 mariadb-10-4 mariadb-10-5 mariadb-10-6 mariadb-10-11 mariadb-11-1 mariadb-11-2 mariadb-11-4 mariadb-11-5 mariadb-11-7 mariadb-11-8
 
 
 .PHONY: build

--- a/Makefile
+++ b/Makefile
@@ -3,24 +3,29 @@ DOCKER_VERSION?=mariadb-11-8
 DOCKER_TAG?=${DOCKER_VERSION}
 DOCKER_VERSIONS=mariadb-10-2 mariadb-10-4 mariadb-10-6 mariadb-10-11 mariadb-11-1 mariadb-11-2 mariadb-11-4 mariadb-11-5 mariadb-11-7 mariadb-11-8
 
-.PHONY: build test run build-all test-all ${DOCKER_VERSIONS}
 
+.PHONY: build
 build:
 	docker build -t ${DOCKER_IMAGE}:${DOCKER_TAG} ${DOCKER_VERSION}/
 
+.PHONY: test
 test:
 	docker run --rm ${DOCKER_IMAGE}:${DOCKER_TAG} mysqldump --version
 	docker run --rm ${DOCKER_IMAGE}:${DOCKER_TAG} mariadb-dump --version
 	docker run --rm ${DOCKER_IMAGE}:${DOCKER_TAG} mariadb --version
 
+.PHONY: run
 run:
 	docker run --rm -it ${DOCKER_IMAGE}:${DOCKER_TAG}
 
+.PHONY: build-all
 build-all:
 	for version in ${DOCKER_VERSIONS}; do ${MAKE} DOCKER_VERSION=$$version DOCKER_TAG=$$version build; done
 
+.PHONY: test-all
 test-all:
 	for version in ${DOCKER_VERSIONS}; do ${MAKE} DOCKER_VERSION=$$version DOCKER_TAG=$$version test; done
 
+.PHONY: ${DOCKER_VERSIONS}
 ${DOCKER_VERSIONS}:
 	${MAKE} DOCKER_VERSION=$@ DOCKER_TAG=$@ build test

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,26 @@
+DOCKER_IMAGE=dockette/dbdump
+VERSION?=mariadb-11-8
+DOCKER_TAG?=${VERSION}
+VERSIONS=mariadb-10-2 mariadb-10-4 mariadb-10-6 mariadb-10-11 mariadb-11-1 mariadb-11-2 mariadb-11-4 mariadb-11-5 mariadb-11-7 mariadb-11-8
+
+.PHONY: build test run build-all test-all ${VERSIONS}
+
+build:
+	docker build -t ${DOCKER_IMAGE}:${DOCKER_TAG} ${VERSION}/
+
+test:
+	docker run --rm ${DOCKER_IMAGE}:${DOCKER_TAG} mysqldump --version
+	docker run --rm ${DOCKER_IMAGE}:${DOCKER_TAG} mariadb-dump --version
+	docker run --rm ${DOCKER_IMAGE}:${DOCKER_TAG} mariadb --version
+
+run:
+	docker run --rm -it ${DOCKER_IMAGE}:${DOCKER_TAG}
+
+build-all:
+	for version in ${VERSIONS}; do ${MAKE} VERSION=$$version DOCKER_TAG=$$version build; done
+
+test-all:
+	for version in ${VERSIONS}; do ${MAKE} VERSION=$$version DOCKER_TAG=$$version test; done
+
+${VERSIONS}:
+	${MAKE} VERSION=$@ DOCKER_TAG=$@ build test

--- a/README.md
+++ b/README.md
@@ -1,18 +1,14 @@
 <h1 align=center>Dockette / DBDUMP</h1>
 
 <p align=center>
+   <a href="https://github.com/dockette/dbdump/actions"><img src="https://github.com/dockette/dbdump/actions/workflows/docker.yml/badge.svg" alt="GitHub Actions"></a>
+   <a href="https://hub.docker.com/r/dockette/dbdump"><img src="https://img.shields.io/docker/pulls/dockette/dbdump.svg" alt="Docker Hub pulls"></a>
+   <a href="https://github.com/sponsors/f3l1x"><img src="https://img.shields.io/badge/sponsor-GitHub%20Sponsors-ea4aaa" alt="GitHub Sponsors"></a>
+   <a href="https://github.com/orgs/dockette/discussions"><img src="https://img.shields.io/badge/support-discussions-6f42c1" alt="Support/Discussions"></a>
+</p>
+
+<p align=center>
    Ready-to-use MariaDB / MySQL / PostgreSQL dumper.
-</p>
-
-<p align=center>
-🕹 <a href="https://f3l1x.io">f3l1x.io</a> | 💻 <a href="https://github.com/f3l1x">f3l1x</a> | 🐦 <a href="https://twitter.com/xf3l1x">@xf3l1x</a>
-</p>
-
-<p align=center>
-    <a href="https://hub.docker.com/r/dockette/dbdump/"><img src="https://img.shields.io/docker/stars/dockette/dbdump.svg?style=flat-square"></a>
-    <a href="https://hub.docker.com/r/dockette/dbdump/"><img src="https://img.shields.io/docker/pulls/dockette/dbdump.svg?style=flat-square"></a>
-    <a href="https://bit.ly/ctteg"><img src="https://img.shields.io/gitter/room/contributte/contributte.svg?style=flat-square"></a>
-    <a href="https://github.com/sponsors/f3l1x"><img src="https://img.shields.io/badge/sponsor-me-brightgreen?style=flat-square"></a>
 </p>
 
 -----
@@ -43,14 +39,12 @@ docker run \
 
 ## Development
 
-See [how to contribute](https://contributte.org/contributing.html) to this package.
+```sh
+make build
+make test
+make run
+```
 
-This package is currently maintaining by these authors.
+## Maintenance
 
-<a href="https://github.com/f3l1x">
-    <img width="80" height="80" src="https://avatars2.githubusercontent.com/u/538058?v=3&s=80">
-</a>
-
------
-
-Consider to [support](https://github.com/sponsors/f3l1x) **f3l1x**. Also thank you for using this package.
+See [how to contribute](https://github.com/dockette/.github/blob/master/CONTRIBUTING.md) to this package. Consider to [support](https://github.com/sponsors/f3l1x) **f3l1x**. Thank you for using this package.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 </p>
 
 <p align=center>
-   Ready-to-use MariaDB / MySQL / PostgreSQL dumper.
+   Ready-to-use MariaDB / MySQL dumper.
 </p>
 
 -----
@@ -21,13 +21,14 @@ docker run \
     --rm \
     -v /data/yourdb:/var/lib/mysql \
     dockette/dbdump:mariadb-10-11 \
-    mysqldump -u root --password=root yourdb > dump.sql
+    mysqldump -u root --password=docker yourdb > dump.sql
 ```
 
 **Images**
 
 - dockette/dbdump:mariadb-10-2
 - dockette/dbdump:mariadb-10-4
+- dockette/dbdump:mariadb-10-5
 - dockette/dbdump:mariadb-10-6
 - dockette/dbdump:mariadb-10-11
 - dockette/dbdump:mariadb-11-1
@@ -43,6 +44,9 @@ docker run \
 make build
 make test
 make run
+make build-all
+make test-all
+make mariadb-11-8
 ```
 
 ## Maintenance


### PR DESCRIPTION
What changed
- Added Makefile build/test/run targets with MariaDB version helpers and DB client smoke checks.
- Added a matrix Test job before the reusable Build job and a Docker Hub Docs job.
- Normalized README badges to the Dockette baseline and added the Maintenance section.

Why
- Brings dockette/dbdump in line with the Dockette CI rollout baseline while keeping the existing image matrix.